### PR TITLE
Include aegir/provision 3.x and load commands when running bin/drush

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,3 +151,4 @@ script:
   - provision -n -v
   - provision status -n
   - bin/drush --filter=provision
+  - bin/drush sa

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,5 +150,5 @@ script:
 
   - provision -n -v
   - provision status -n
-  - bin/drush --filter=provision
   - bin/drush sa
+  - bin/drush --filter=provision

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,3 +150,4 @@ script:
 
   - provision -n -v
   - provision status -n
+  - bin/drush --filter=provision

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "license": "GPL-2.0+",
     "require": {
+        "aegir/provision": "dev-7.x-3.x",
         "consolidation/Robo": "dev-block-output",
         "consolidation/annotated-command": "~2",
         "drupal/console-core": "1.0.2",
@@ -48,5 +49,10 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {"Aegir\\Provision\\": "src/Provision"}
+    },
+    "scripts": {
+        "post-package-install": [
+            "Aegir\\Provision\\Console\\ComposerScripts::writeDrushRcForVendorDrushDrush"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "psr-4": {"Aegir\\Provision\\": "src/Provision"}
     },
     "scripts": {
-        "post-package-install": [
+        "post-install-cmd": [
             "Aegir\\Provision\\Console\\ComposerScripts::writeDrushRcForVendorDrushDrush"
         ]
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,43 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a25b24761df3282da478cb6fb3b3358",
+    "content-hash": "d0c25882c73d1f35a778a56e99a10fe1",
     "packages": [
+        {
+            "name": "aegir/provision",
+            "version": "dev-7.x-3.x",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aegir-project/provision.git",
+                "reference": "5fb408fc03bf68afbb39ecf5e37a2cec96656f26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aegir-project/provision/zipball/5fb408fc03bf68afbb39ecf5e37a2cec96656f26",
+                "reference": "5fb408fc03bf68afbb39ecf5e37a2cec96656f26",
+                "shasum": ""
+            },
+            "type": "drupal-drush",
+            "autoload": {
+                "psr-0": {
+                    "Provision_": [
+                        "Provision"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Aegir maintainers",
+                    "homepage": "http://docs.aegirproject.org/en/3.x/community/core-team/"
+                }
+            ],
+            "description": "Drush commands powering the back-end of Aegir",
+            "time": "2018-04-19T14:27:59+00:00"
+        },
         {
             "name": "consolidation/annotated-command",
             "version": "2.8.3",
@@ -2301,6 +2336,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "aegir/provision": 20,
         "consolidation/robo": 20
     },
     "prefer-stable": true,

--- a/src/Provision/Application.php
+++ b/src/Provision/Application.php
@@ -3,6 +3,7 @@
 namespace Aegir\Provision;
 
 use Aegir\Provision\Command\CdCommand;
+use Aegir\Provision\Command\DrushCommand;
 use Aegir\Provision\Command\SaveCommand;
 use Aegir\Provision\Command\ServicesCommand;
 use Aegir\Provision\Command\SetupCommand;
@@ -145,6 +146,7 @@ class Application extends BaseApplication
     protected function getDefaultCommands()
     {
         $commands[] = new CdCommand();
+        $commands[] = new DrushCommand();
         $commands[] = new HelpCommand();
         $commands[] = new ListCommand();
         $commands[] = new SaveCommand();

--- a/src/Provision/Command/DrushCommand.php
+++ b/src/Provision/Command/DrushCommand.php
@@ -42,7 +42,11 @@ class DrushCommand extends Command
         $inputDefinition[] = new InputArgument(
             'drush_command_string',
             InputArgument::OPTIONAL,
-            'The full drush command to run including options.'
+            'The full drush command to run including options. Pass the entire command including options in a string:
+                 Examples:
+                 $  provision drush "status --fields=root,uri,drupal-version"
+               
+            '
         );
         return $inputDefinition;
     }
@@ -60,7 +64,10 @@ class DrushCommand extends Command
 
         // Generate the full path and command. (Currently using built in drush (v8)
         // Provision's built in drush acts as a wrapper for site local drush when run in that directory.
-        $command = dirname(dirname(dirname(dirname(__FILE__)))) . '/bin/drush ' . $input->getArgument('drush_command_string');
+        $root = $this->context->getProperty('root');
+        $uri = $this->context->getProperty('uri');
+
+        $command = dirname(dirname(dirname(dirname(__FILE__)))) . '/bin/drush ' . $input->getArgument('drush_command_string') . " --root=$root --uri=$uri ";
 
         $this->getProvision()->getLogger()->debug("Running $command");
 

--- a/src/Provision/Command/DrushCommand.php
+++ b/src/Provision/Command/DrushCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Aegir\Provision\Command;
+
+use Aegir\Provision\Command;
+use Aegir\Provision\Provision;
+use Psy\Shell;
+use Psy\Configuration;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class DrushCommand
+ *
+ * @package Aegir\Provision\Command
+ */
+class DrushCommand extends Command
+{
+    const CONTEXT_REQUIRED = TRUE;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('drush')
+            ->setDescription($this->trans('commands.drush.description'))
+            ->setHelp($this->trans('commands.drush.help'))
+            ->setDefinition($this->getCommandDefinition());
+          ;
+    }
+
+    /**
+     * Generate the list of options derived from ProvisionContextType classes.
+     *
+     * @return \Symfony\Component\Console\Input\InputDefinition
+     */
+    protected function getCommandDefinition() {
+        $inputDefinition[] = new InputArgument(
+            'drush_command_string',
+            InputArgument::OPTIONAL,
+            'The full drush command to run including options.'
+        );
+        return $inputDefinition;
+    }
+
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return int|null|void
+     * @throws \Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        // Generate the full path and command. (Currently using built in drush (v8)
+        // Provision's built in drush acts as a wrapper for site local drush when run in that directory.
+        $command = dirname(dirname(dirname(dirname(__FILE__)))) . '/bin/drush ' . $input->getArgument('drush_command_string');
+
+        $this->getProvision()->getLogger()->debug("Running $command");
+
+        $this->context->process_exec($command, $this->context->getWorkingDir());
+    }
+}

--- a/src/Provision/Console/ComposerScripts.php
+++ b/src/Provision/Console/ComposerScripts.php
@@ -31,9 +31,17 @@ class ComposerScripts {
         if (file_exists($root_dir) && is_writable($root_dir)) {
             $drushrc = <<<PHP
 <?php
+
+// Includes the Aegir Provision 3.x drush commands when running bin/drush.
 \$options['include'] = array(
     dirname(dirname(dirname(__FILE__))) . '/aegir/provision',
 );
+
+// Dynamically loads Provision4 context data into aegir/provision 7.x-3.x drush aliases!
+\$options['alias-path'] = array(
+    dirname(dirname(dirname(dirname(__FILE__)))) . '/src/Provision/Console/Provision3Aliases',
+);
+
 PHP;
             if (file_put_contents($root_dir . '/drushrc.php', $drushrc)) {
                 print "Wrote drushrc.php to $root_dir \n";

--- a/src/Provision/Console/ComposerScripts.php
+++ b/src/Provision/Console/ComposerScripts.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file ComposerScripts.php
+ *
+ * This file is not meant to be loaded by provision as it requires Composer classes.
+ *
+ * Currently it only contains one "script": writeDrushRcForVendorDrushDrush()
+ *
+ * This is used on composer install to copy a drushrc.php file into vendor/drush/drush.
+ *
+ * This drushrc.php file is used to include the provision 3.x drush commands.
+ *
+ */
+
+namespace Aegir\Provision\Console;
+
+use Composer\Script\Event;
+use Composer\Installer\PackageEvent;
+
+class ComposerScripts {
+
+    /**
+     * @param \Composer\Installer\PackageEvent $event
+     *
+     * @throws \Exception
+     */
+    public static function writeDrushRcForVendorDrushDrush(PackageEvent $event)
+    {
+        $root_dir = dirname(dirname(dirname(dirname(__FILE__)))) . '/vendor/drush/drush';
+        if ($event->getOperation()->getPackage()->getName() == 'drush/drush' && file_exists($root_dir) && is_writable($root_dir)) {
+            $drushrc = <<<PHP
+<?php
+\$options['include'] = array(
+    dirname(dirname(dirname(__FILE__))) . '/aegir/provision',
+);
+PHP;
+            if (file_put_contents($root_dir . '/drushrc.php', $drushrc)) {
+                print "Wrote drushrc.php to $root_dir \n";
+            }
+        }
+        else {
+            throw new \Exception("Directory $root_dir does not exist or is not writable. Provision cannot load it's commands.");
+        }
+    }
+}

--- a/src/Provision/Console/ComposerScripts.php
+++ b/src/Provision/Console/ComposerScripts.php
@@ -21,14 +21,14 @@ use Composer\Installer\PackageEvent;
 class ComposerScripts {
 
     /**
-     * @param \Composer\Installer\PackageEvent $event
+     * @param \Composer\Script\Event $event
      *
      * @throws \Exception
      */
-    public static function writeDrushRcForVendorDrushDrush(PackageEvent $event)
+    public static function writeDrushRcForVendorDrushDrush(Event $event)
     {
         $root_dir = dirname(dirname(dirname(dirname(__FILE__)))) . '/vendor/drush/drush';
-        if ($event->getOperation()->getPackage()->getName() == 'drush/drush' && file_exists($root_dir) && is_writable($root_dir)) {
+        if (file_exists($root_dir) && is_writable($root_dir)) {
             $drushrc = <<<PHP
 <?php
 \$options['include'] = array(

--- a/src/Provision/Console/Provision3Aliases/aliases.drushrc.php
+++ b/src/Provision/Console/Provision3Aliases/aliases.drushrc.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file aliases.drushrc.php
+ *
+ * This file is used as a shim between Provision4 and Aegir Provision 7.x-3.x.
+ *
+ * It is used to generate "drush aliases" from the Provision 4 contexts.
+ *
+ * When you run bin/drush in the provision folder, it will load all of these aliases.
+ *
+ * This only works if drushrc.php is configured to look in this folder for aliases.
+ *
+ * This is done on `composer install` using  Aegir\Provision\Console\ComposerScripts:
+ *
+ * We copy a small drushrc.php file into the vendor/drush/drush folder so we can
+ * force configuration on every bin/drush command.
+ *
+ * The reason we need a shim is that Provision 3.x has a lot of drush commands
+ * that will take some time to migrate to Symfony Console commands.
+ *
+ * For now we will run both side by side.
+ *
+ * When all Provision commands are converted, we will bump to 4.1.x
+ *
+ */
+
+
+# Load Provision4 Autoloader
+include dirname(dirname(dirname(dirname(__FILE__)))) . '/vendor/autoload.php';
+
+# Loop through all Provision4 Contexts
+foreach (Aegir\Provision\Provision::getProvision()->getAllContexts() as $context) {
+
+    # Load all context properties as an alias.
+    $aliases[$context->name] = $context->getProperties();
+
+    # @TODO: Refactor the alias data so it is compatible with Provision 3.x API.
+
+}

--- a/src/Provision/Context.php
+++ b/src/Provision/Context.php
@@ -130,6 +130,18 @@ class Context implements BuilderAwareInterface
     }
 
     /**
+     * @return string Working directory for the context. Either the site or platform root, or the server config path.
+     */
+    public function getWorkingDir() {
+        if ($this->hasProperty('root')) {
+            return $this->getProperty('root');
+        }
+        elseif ($this->hasProperty('server_config_path')) {
+            return $this->getProperty('server_config_path');
+        }
+    }
+
+    /**
      * Load and process the Config object for this context.
      *
      * @param array $options


### PR DESCRIPTION
The purpose of this PR is to get Drush and Provision 3.x embedded in provision4.

If we can use `verify` and `save` from provision4 and pass the rest to drush and provision3 commands, we can get a 4.0.x out the door.

This PR:

- [x] includes aegir/provision:3.x via composer! thanks to https://www.drupal.org/project/provision/issues/2957156
- [x] Adds a `provision drush` command that just passes through to bin/drush.
- [x] Dynamically configures drush to load the provision 3.x drush8 commands, and to dynamically create provision3.x drush aliases from Provision4 context data!
- [x] Adds bin/drush sa and lists the provision commands in the travis yml. Ooh pretty: https://travis-ci.org/provision4/provision/jobs/368846027#L1388


Got that!?? Amazing, right?

Well, this will let us release fast and get pro4 into production without having to rewrite the entire thing first! 