### PR TITLE
Dynamically apply volume flags depending on the system

### DIFF
--- a/src/Provision/Service/Http/HttpApacheDockerService.php
+++ b/src/Provision/Service/Http/HttpApacheDockerService.php
@@ -270,7 +270,7 @@ class HttpApacheDockerService extends HttpApacheService implements DockerService
         $volumes = array();
 
         $config_path_host = $config_path_container = $this->provider->getProperty('server_config_path');
-        $volumes[] = "{$config_path_host}:/var/provision/config/{$this->provider->name}:z";
+        $volumes[] = "{$config_path_host}:/var/provision/config/{$this->provider->name}{$this->provider->dockerCompose->getVolumeFlags()}";
 
 //        $platforms_path_host = $platforms_path_container = d()->http_platforms_path;
 //
@@ -294,7 +294,7 @@ class HttpApacheDockerService extends HttpApacheService implements DockerService
         foreach ($contexts as $context) {
             if ($context instanceof ServiceSubscriber && $context->getSubscription('http')->server->name == $this->provider->name) {
                 $container_path = $this->mapContainerPath($context->getProperty('root'));
-                $volumes[$container_path] = $context->getProperty('root') . ':' . $container_path . ':z';
+                $volumes[$container_path] = $context->getProperty('root') . ':' . $container_path . $this->provider->dockerCompose->getVolumeFlags();
             }
         }
 


### PR DESCRIPTION
If using Docker for Mac, you can get greatly increased performance by using volume flags. You should use "delegated" flag.

If you are using SELinux, (on an OS like Fedora) you want the ":z" flag in case you attach more containers.

If the user wants to override the volume flags completely, they can now using the `.provision.yml` file.

